### PR TITLE
fix for unsolicited replies not starting reliably

### DIFF
--- a/ft8ctrl.py
+++ b/ft8ctrl.py
@@ -74,12 +74,13 @@ class Sequencer:
     packet.call = data['call']
     packet.Time = data['time']
     packet.SNR = data['snr']
+    # TODO: use self.follow_frequency here to control whether or not to change the TX frequency
     packet.DeltaTime = pkt['DeltaTime']
     packet.DeltaFrequency = pkt['DeltaFrequency']
     packet.Mode = pkt['Mode']
     packet.Message = pkt['Message']
-    if self.follow_frequency:
-      packet.Modifiers = wsjtx.Modifiers.SHIFT
+    # always set the SHIFT modifier to ensure TX is enabled
+    packet.Modifiers = wsjtx.Modifiers.SHIFT
 
     LOG.debug('Transmitting %s', packet)
     try:


### PR DESCRIPTION
Unsolicited responses were not causing WSJTX to enable the transmitter because the SHIFT modifier was not set. Apparently the SHIFT modifier is required when responding to a non-CQ.

With this modification, the new QSO will always retune the TX to the station it is calling. It should be possible for the "follow_frequency" attribute to control this by having it change the value of packet.DeltaFrequency (0 might mean no change?) but this was not attempted in this PR. 