### PR TITLE
Add multicast group support and unit tests for WSJT-X socket

### DIFF
--- a/ft8ctrl.py
+++ b/ft8ctrl.py
@@ -11,6 +11,7 @@ import os
 import re
 import select
 import socket
+import struct
 import time
 from argparse import ArgumentParser
 from datetime import datetime
@@ -54,11 +55,31 @@ class Sequencer:
     self.tx_retries = getattr(config, 'tx_retries', 5)
     self.enable_unsolicited = getattr(config, 'enable_unsolicited', True)
 
-    bind_addr = socket.gethostbyname(config.wsjt_ip)
+    # Determine bind address; handle multicast groups specially
+    raw_ip = config.wsjt_ip
+    try:
+      first_octet = int(raw_ip.split('.')[0])
+    except (ValueError, IndexError):
+      first_octet = None
+    if first_octet is not None and 224 <= first_octet <= 239:
+      bind_addr = '0.0.0.0'
+    else:
+      bind_addr = socket.gethostbyname(raw_ip)
+    # Create and configure socket
     self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    self.sock.setblocking(False)  # Set socket to non-blocking mode
+    # Allow reuse port on platforms that support it
+    try:
+      self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+    except (AttributeError, OSError):
+      pass
+    self.sock.setblocking(False)
     self.sock.bind((bind_addr, config.wsjt_port))
+    # If binding to multicast group, join it
+    if first_octet is not None and 224 <= first_octet <= 239:
+      mreq = struct.pack('4s4s', socket.inet_aton(raw_ip), socket.inet_aton(bind_addr))
+      self.sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
+      LOG.info('Joined multicast group %s on interface %s', raw_ip, bind_addr)
 
     self.logger_ip = getattr(config, 'logger_ip', None)
     self.logger_port = getattr(config, 'logger_port', None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import types
+# Add project root to sys.path so ft8ctrl can be imported
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))) 
+
+# Stub dbutils to avoid missing dependencies
+_dbutils = types.ModuleType('dbutils')
+_dbutils.DBCommand = types.SimpleNamespace(INSERT=None, DELETE=None, STATUS=None)
+_dbutils.DBInsert = lambda *args, **kwargs: None
+_dbutils.Purge = lambda *args, **kwargs: None
+_dbutils.create_db = lambda *args, **kwargs: None
+_dbutils.get_band = lambda x: x
+sys.modules['dbutils'] = _dbutils
+
+# Stub wsjtx to avoid missing dependency
+sys.modules['wsjtx'] = types.ModuleType('wsjtx')
+
+# Initialize ft8ctrl.LOG to a valid logger to prevent AttributeError during tests
+import logging
+import ft8ctrl
+ft8ctrl.LOG = logging.getLogger('ft8ctrl_test') 

--- a/tests/test_multicast.py
+++ b/tests/test_multicast.py
@@ -1,0 +1,54 @@
+import socket
+import struct
+from types import SimpleNamespace
+import pytest
+from ft8ctrl import Sequencer
+
+class DummySocket:
+    def __init__(self, *args, **kwargs):
+        self.options = []
+    def setsockopt(self, level, optname, value):
+        # Record all setsockopt calls
+        self.options.append((level, optname, value))
+    def setblocking(self, flag):
+        pass
+    def bind(self, addr):
+        self.bound_addr = addr
+
+@pytest.fixture(autouse=True)
+def dummy_socket(monkeypatch):
+    # Replace socket.socket with DummySocket for all tests
+    monkeypatch.setattr(socket, 'socket', lambda *args, **kwargs: DummySocket())
+
+
+def make_config(ip):
+    # Helper to create a minimal config object
+    return SimpleNamespace(
+        wsjt_ip=ip,
+        wsjt_port=12345,
+        my_call='CALL',
+        follow_frequency=False,
+        tx_power=None,
+        tx_retries=5,
+        enable_unsolicited=True,
+        logger_ip=None,
+        logger_port=None
+    )
+
+
+def test_multicast_join():
+    raw_ip = '224.0.0.1'
+    config = make_config(raw_ip)
+    seq = Sequencer(config, queue=None, call_select=None)
+    # membership request should be for group raw_ip on 0.0.0.0
+    mreq = struct.pack('4s4s', socket.inet_aton(raw_ip), socket.inet_aton('0.0.0.0'))
+    assert (socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq) in seq.sock.options
+
+
+def test_unicast_no_multicast():
+    raw_ip = '127.0.0.1'
+    config = make_config(raw_ip)
+    seq = Sequencer(config, queue=None, call_select=None)
+    # ensure no IP_ADD_MEMBERSHIP option added for unicast address
+    added = [opt for opt in seq.sock.options if opt[0] == socket.IPPROTO_IP and opt[1] == socket.IP_ADD_MEMBERSHIP]
+    assert not added 


### PR DESCRIPTION
Add support for connecting to WSJT-X using a multicast address (e.g. 224.0.0.1). Also add a unit test to confirm the socket connection can be opened in both unicast and multicast mode.

Some other WSJT-X helper software (e.g. JTAlert) require connecting via multi-cast. This change enables FT8 commander to co-exist peacefully.